### PR TITLE
feat(HACBS-467): add tekton task to filter snapshot

### DIFF
--- a/definitions/component-mapping/component-mapping.yaml
+++ b/definitions/component-mapping/component-mapping.yaml
@@ -5,6 +5,9 @@ metadata:
   name: m5-release-pipeline
 spec:
   params:
+    - name: ApplicationSnapshot
+      type: string
+      description: The ApplicationSnapshot in JSON format to release
     - name: mapping-file
       type: string
       description: The mapping to apply to the snapshot
@@ -16,6 +19,14 @@ spec:
       params:
         - name: mapping-file
           value: "$(params.mapping-file)"
+    - name: apply-mapping
+      taskRef:
+        name: apply-mapping
+      params:
+        - name: application-snapshot
+          value: "$(params.ApplicationSnapshot)"
+        - name: mapping
+          value: "$(tasks.get-mapping-file.results.mapping)"
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -36,3 +47,27 @@ spec:
         #!/usr/bin/env bash
         mapping=$(curl $(params.mapping-file) | yq -o=json -I=0)
         echo ${mapping} | tee $(results.mapping.path)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: apply-mapping
+spec:
+  params:
+    - name: application-snapshot
+      type: string
+      description: The ApplicationSnapshot in JSON format to apply the mapping to
+    - name: mapping
+      type: string
+      description: The mapping to apply to the snapshot
+  results:
+    - name: filtered-snapshot
+      description: The filtered AppicationSnapshot of images
+  steps:
+    - name: apply-mapping
+      image: quay.io/hacbs-release/release-utils
+      script: |
+        #!/usr/bin/env bash
+        curl -O -L https://raw.githubusercontent.com/hacbs-release/strategy-utils/main/filter.py
+        chmod +x filter.py
+        python3 filter.py '$(params.application-snapshot)' '$(params.mapping)' | tee $(results.filtered-snapshot.path)


### PR DESCRIPTION
This commit adds a tekton task to the component-mapping
bundle that will apply the provided mapping to the passed
ApplicationSnapshot. Images that do not exist in the
mapping will be removed, and images that do exist in the
mapping will have a key specifying their destination
added.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>