### PR TITLE
feat(HACBS-539): add Tekton bundle to clone repositories

### DIFF
--- a/definitions/git-clone/README.md
+++ b/definitions/git-clone/README.md
@@ -1,0 +1,35 @@
+# git-clone
+
+Tekton task to clone remote repositories into a Tekton workspace named `output`.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| url | The URL to clone from | No | - |
+| revision | Revision to checkout (branch, tag, sha, ref, etc...) | Yes | - |
+| subdirectory | Subdirectory inside the `output` Workspace to clone the repo into | Yes | - |
+| deleteExisting | Whether to clean out the contents of the destination directory if it already exists before cloning | Yes | "true" |
+| verbose | Whether this task script should show verbose output | Yes | "false" |
+
+## Example usage
+
+This is an example usage of the `git-clone` task:
+
+```
+---
+tasks:
+  - name: git-clone
+    taskRef:
+      name: git-clone
+    params:
+      - name: url
+        value: git@github.com:foo/bar.git
+    workspaces:
+      - name: output
+        workspace: output
+```
+
+## Private repositories
+
+To clone private repositories, a service account has to be defined in the PipelineRun/TaskRun with a linked secret allowing to connect to the repository using SSH. More information on this can be found in the [official documentation](https://tekton.dev/docs/pipelines/auth/#configuring-ssh-auth-authentication-for-git).

--- a/definitions/git-clone/git-clone.yaml
+++ b/definitions/git-clone/git-clone.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  params:
+    - name: url
+      type: string
+      description: The URL to clone from
+    - name: revision
+      type: string
+      description: Revision to checkout (branch, tag, sha, ref, etc...)
+      default: ""
+    - name: subdirectory
+      type: string
+      description: >
+        Subdirectory inside the `output` Workspace to clone the repo into
+      default: ""
+    - name: deleteExisting
+      type: string
+      description: >
+        Whether to clean out the contents of the destination directory if
+        it already exists before cloning
+      default: "true"
+    - name: verbose
+      type: string
+      description: Whether this task script should show verbose output
+      default: "false"
+  workspaces:
+    - name: output
+      description: Workspace where the git repository will be cloned into
+  steps:
+    - name: clone
+      image: quay.io/hacbs-release/release-utils
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "$(params.verbose)" = "true" ]; then
+          set -x
+        fi
+
+        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+
+        if [ "$(params.deleteExisting)" = "true" ]; then
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus
+            # any other character.
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        fi
+
+        if [ -z "$(params.revision)" ]; then
+          git clone "$(params.url)" "${CHECKOUT_DIR}"
+        else
+          git clone -b "$(params.revision)" "$(params.url)" "${CHECKOUT_DIR}"
+        fi


### PR DESCRIPTION
This new Tekton bundles allows to clone repositories into a given `output` workspace, so we can fetch strategy configs from remote repositories.

Signed-off-by: David Moreno García <damoreno@redhat.com>