### PR TITLE
feat(HACBS-562): add fake-ec-validation bundle

### DIFF
--- a/definitions/fake-ec-validation/README.md
+++ b/definitions/fake-ec-validation/README.md
@@ -1,0 +1,26 @@
+# validate-enterprise-contract
+
+Tekton task to fake an Enterprise Contract validation.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| applicationSnapshot | JSON representation of the ApplicationSnapshot being released | Yes | - |
+| policy | Name of the policy to apply when validating the enterprise contract | Yes | - |
+| shouldFail | Whether the validation should fail or not | Yes | "false" |
+
+## Example usage
+
+This is an example usage of the `validate-enterprise-contract` task:
+
+```
+---
+tasks:
+  - name: validate-enterprise-contract
+    taskRef:
+      name: validate-enterprise-contract
+    params:
+      - name: shouldFail
+        value: "true"
+```

--- a/definitions/fake-ec-validation/validate_enterprise_contract.yaml
+++ b/definitions/fake-ec-validation/validate_enterprise_contract.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: validate-enterprise-contract
+spec:
+  params:
+    - name: applicationSnapshot
+      type: string
+      description: JSON representation of the ApplicationSnapshot being released
+      default: ""
+    - name: policy
+      type: string
+      description: Name of the policy to apply when validating the enterprise contract
+      default: ""
+    - name: shouldFail
+      type: string
+      description: Whether the validation should fail or not
+      default: "false"
+  steps:
+    - name: fake-ec-validation
+      image: quay.io/hacbs-release/release-utils
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "$(params.shouldFail)" = "true" ]; then
+          exit 1
+        fi


### PR DESCRIPTION
This bundle can be used to fake an EC validation. It contains a validate-enterprise-contract task to which a shouldFail parameter can be passed. This parameter will simulate an error in the validation process.

Signed-off-by: David Moreno García <damoreno@redhat.com>