### PR TITLE
bug: troubleshooting quay API calls using token.

### DIFF
--- a/.github/scripts/tkn_push_bundles.sh
+++ b/.github/scripts/tkn_push_bundles.sh
@@ -60,7 +60,7 @@ do
     curl \
       --silent \
       --request GET "${API_HTTP}/repository?namespace=${IMAGE_NAMESPACE}" \
-      --header 'Authorization: Bearer ${QUAY_API_TOKEN}' | \
+      --header "Authorization: Bearer ${QUAY_API_TOKEN}" | \
     jq '.repositories[].name'
   )
   then
@@ -73,7 +73,7 @@ do
     curl \
       --silent \
       --request POST "${API_HTTP}/repository?namespace=${IMAGE_NAMESPACE}" \
-      --header 'Authorization: Bearer ${QUAY_API_TOKEN}' \
+      --header "Authorization: Bearer ${QUAY_API_TOKEN}" \
       --header 'Content-Type: application/json' \
       --data "$new_repo_string"
   fi

--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -35,4 +35,4 @@ jobs:
           GITHUB_REFNAME: ${{ github.ref_name }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
-          QUAY_API_TOKEN: ${{ secrets.QUAY_API_TOKEN }}
+          QUAY_API_TOKEN: ${{ env.API_TOKEN }}


### PR DESCRIPTION
The workflow has a new error creating the repo prior to pushing bundles.
```
Creating new repo: quay.io/hacbs-release/fake-ec-validation
{"message": "CSRF token was invalid or missing."}
```

* The API token exists on Quay, and has the correct permissions
  requred to create new image repos.
* curl cmdline to list repos using the Quay oath2 API token was proven
  to work from my laptop, so it's known to be good.
* The associated GitHub secret for the API token was updated to ensure
  it was the same one established at Quay.
* Workflows were re-run to test the aforementioned things.

This commit is to help determine if the problem is with passing GitHub secret
contexts to the scripting environment. Other secret contexts were passed
from the outer environment, so this change aligns the Quay API_TOKEN the
same way. Also, the shell quoting was switched to double quotes to
ensure env vars are substituted properly. Apparently GitHub contexts
work with single-quotes, which were used in a few key places.

Jira: HACBS-566

Signed-off-by: Jon Disnard <jdisnard@redhat.com>