### PR TITLE
feat(HACBS-599): add skopeo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -
 RUN dnf -y --setopt=tsflags=nodocs install \
     git \
     python3 \
+    skopeo \
     && dnf clean all


### PR DESCRIPTION
Skopeo will be needed by one of our Tekton tasks. That task should use the release-utils image, so we need to update the Dockerfile to add it.

Signed-off-by: David Moreno García <damoreno@redhat.com>