### PR TITLE
feat(HACBS-609): create prepare-validation task

### DIFF
--- a/definitions/prepare-validation/README.md
+++ b/definitions/prepare-validation/README.md
@@ -1,0 +1,26 @@
+# prepare-validation
+
+Tekton task to extract a pull spec from an Application Snapshot.
+
+The purpose of this task is to extract just a single component's pullSpec from a passed Application Snapshot.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| applicationSnapshot | The ApplicationSnapshot in JSON format to apply the mapping to | No | - |
+
+## Example usage
+
+This is an example usage of the `prepare-validation` task:
+
+```
+---
+tasks:
+  - name: prepare-validation
+    taskRef:
+      name: prepare-validation
+    params:
+      - name: applicationSnapshot
+        value: '{"images":[{"component":"component1","pullSpec":"quay.io/repo/component1:digest"}}]}'
+```

--- a/definitions/prepare-validation/prepare-validation.yaml
+++ b/definitions/prepare-validation/prepare-validation.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: prepare-validation
+spec:
+  params:
+    - name: applicationSnapshot
+      type: string
+      description: The ApplicationSnapshot in JSON format to apply the mapping to
+  results:
+    - name: applicationSnapshot
+      description: |
+        The pullSpec of the first component in the passed AppicationSnapshot.
+  steps:
+    - name: prepare-validation
+      image: quay.io/hacbs-release/release-utils
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        jq -r '.images[0].pullSpec' <<< '$(params.applicationSnapshot)' | tee $(results.applicationSnapshot.path)


### PR DESCRIPTION
This commit adds the prepare-validation task which will extract the first
component's pullSpec from an application snapshot. It is just for m5 and
should be reverted later on, once the Enterprise Contract task accepts a
full snapshot instead of just an IMAGE_REF.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>