### PR TITLE
fix(HACBS-615): set HOME variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,6 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     git \
     skopeo \
     && dnf clean all
+
+# Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
+ENV HOME=/tekton/home


### PR DESCRIPTION
Tekton tasks need to have a HOME variable set to anything else than `/` so credentials can be copied.

Signed-off-by: David Moreno García <damoreno@redhat.com>