### PR TITLE
feat: return mapped result in apply-mapping

### DIFF
--- a/definitions/apply-mapping/README.md
+++ b/definitions/apply-mapping/README.md
@@ -7,6 +7,9 @@ The mapping is expected to be present in the passed `extraConfigPath`. If the fi
 the file contains no `mapping` key, the original Application Snapshot is returned. If there is a
 `mapping` key, it is merged with the `images` key in the Application Snapshot based on component.
 
+A `mapped` result is also returned from this task containing a simple true/false value that is
+meant to inform whether a mapped Application Snapshot is being returned or the original one.
+
 ## Parameters
 
 | Name | Description | Optional | Default value |

--- a/definitions/apply-mapping/apply-mapping.yaml
+++ b/definitions/apply-mapping/apply-mapping.yaml
@@ -20,6 +20,8 @@ spec:
       description: |
         The AppicationSnapshot in JSON format with the mapping applied. If there is no mapping key in the
         extraConfigPath, this result will be the same as the original applicationSnapshot parameter.
+    - name: mapped
+      description: A true/false value depicting whether or not the applicationSnapshot was mapped.
   steps:
     - name: apply-mapping
       image: quay.io/hacbs-release/release-utils
@@ -34,11 +36,13 @@ spec:
         if [ ! -f "${CONFIG_FILE}" ] ; then
             echo "No valid config file was provided."
             echo "${APPLICATION_SNAPSHOT}" | tee $(results.applicationSnapshot.path)
+            echo "false" | tee $(results.mapped.path)
             exit 0
         fi
         if [[ $(yq '.mapping' "${CONFIG_FILE}") == "null" ]] ; then
             echo "Config file contains no mapping key."
             echo "${APPLICATION_SNAPSHOT}" | tee $(results.applicationSnapshot.path)
+            echo "false" | tee $(results.mapped.path)
             exit 0
         fi
 
@@ -51,3 +55,5 @@ spec:
           | [.[] | select(length > 1)] | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents
           | $snapshot | .images = $mergedComponents' \
           <<< "${APPLICATION_SNAPSHOT}${CONFIG_JSON}" | tee $(results.applicationSnapshot.path)
+
+        echo "true" | tee $(results.mapped.path)


### PR DESCRIPTION
This commit modifies the apply-mapping task to return a result named
mapped. The value of mapped is true if the snapshot had a mapping
applied and false otherwise.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>