### PR TITLE
fix: add option to jq in prepare-validation

### DIFF
--- a/definitions/prepare-validation/prepare-validation.yaml
+++ b/definitions/prepare-validation/prepare-validation.yaml
@@ -19,4 +19,4 @@ spec:
         #!/usr/bin/env sh
         set -eux
 
-        jq -r '.images[0].pullSpec' <<< '$(params.applicationSnapshot)' | tee $(results.applicationSnapshot.path)
+        jq -jr '.images[0].pullSpec' <<< '$(params.applicationSnapshot)' | tee $(results.applicationSnapshot.path)


### PR DESCRIPTION
Add the -j option to the jq command used in the prepare
validation task.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>