### PR TITLE
bug: Use type string instead of int in Tekton task

### DIFF
--- a/definitions/skopeo-copy/skopeo-copy.yaml
+++ b/definitions/skopeo-copy/skopeo-copy.yaml
@@ -19,8 +19,8 @@ spec:
       type: string
     - name: retries
       description: Retry skopeo copy N times.
-      type: int
-      default: 0
+      type: string
+      default: "0"
   steps:
     - name: skopeo-copy
       image: quay.io/skopeo/stable:v1.7.0


### PR DESCRIPTION
* According to docs int types are not valid.
* This change allows `tkn bunlde push` cli to properly parse the yaml.

https://tekton.dev/docs/pipelines/tasks/#specifying-parameters

jira: hacbs-678

Signed-off-by: Jon Disnard <jdisnard@redhat.com>