### PR TITLE
feat(HACBS-665): switch to GitOps ApplicationSnapshot CRD

### DIFF
--- a/definitions/apply-mapping/README.md
+++ b/definitions/apply-mapping/README.md
@@ -2,10 +2,10 @@
 
 Tekton task to apply a mapping to an Application Snapshot.
 
-The purpose of this task is to merge a mapping with the images contained in an Application Snapshot.
+The purpose of this task is to merge a mapping with the components contained in an Application Snapshot.
 The mapping is expected to be present in the passed `extraConfigPath`. If the file is not found or
 the file contains no `mapping` key, the original Application Snapshot is returned. If there is a
-`mapping` key, it is merged with the `images` key in the Application Snapshot based on component.
+`mapping` key, it is merged with the `components` key in the Application Snapshot based on component name.
 
 A `mapped` result is also returned from this task containing a simple true/false value that is
 meant to inform whether a mapped Application Snapshot is being returned or the original one.
@@ -29,7 +29,7 @@ tasks:
       name: apply-mapping
     params:
       - name: applicationSnapshot
-        value: '{"images":[{"component":"component1","pullSpec":"quay.io/repo/component1:digest"}}]}'
+        value: '{"components":[{"name":"component1","containerImage":"quay.io/repo/component1:digest"}}]}'
       - name: extraConfigPath
         value: "path/to/file"
     workspaces:

--- a/definitions/apply-mapping/apply-mapping.yaml
+++ b/definitions/apply-mapping/apply-mapping.yaml
@@ -49,11 +49,11 @@ spec:
         # Create JSON representation of the config so we can use jq
         CONFIG_JSON=$(yq -o=json -I=0 '.' "${CONFIG_FILE}")
 
-        # Merge the mapping key in the config file with the images key in the snapshot based on component name
+        # Merge the mapping key in the config file with the components key in the snapshot based on component name
         # Save the output as a compact json in applicationSnapshot task result
-        jq -c -s '.[0] as $snapshot | .[0].images + .[1].mapping | group_by(.component)
+        jq -c -s '.[0] as $snapshot | .[0].components + .[1].mapping.components | group_by(.name)
           | [.[] | select(length > 1)] | map(reduce .[] as $x ({}; . * $x)) as $mergedComponents
-          | $snapshot | .images = $mergedComponents' \
+          | $snapshot | .components = $mergedComponents' \
           <<< "${APPLICATION_SNAPSHOT}${CONFIG_JSON}" | tee $(results.applicationSnapshot.path)
 
         echo "true" | tee $(results.mapped.path)

--- a/definitions/prepare-validation/README.md
+++ b/definitions/prepare-validation/README.md
@@ -22,5 +22,5 @@ tasks:
       name: prepare-validation
     params:
       - name: applicationSnapshot
-        value: '{"images":[{"component":"component1","pullSpec":"quay.io/repo/component1:digest"}}]}'
+        value: '{"components":[{"name":"component1","containerImage":"quay.io/repo/component1:digest"}}]}'
 ```

--- a/definitions/prepare-validation/prepare-validation.yaml
+++ b/definitions/prepare-validation/prepare-validation.yaml
@@ -19,4 +19,5 @@ spec:
         #!/usr/bin/env sh
         set -eux
 
-        jq -jr '.images[0].pullSpec' <<< '$(params.applicationSnapshot)' | tee $(results.applicationSnapshot.path)
+        jq -jr '.components[0].containerImage' <<< '$(params.applicationSnapshot)' \
+          | tee $(results.applicationSnapshot.path)

--- a/definitions/push-application-snapshot/push-application-snapshot.yaml
+++ b/definitions/push-application-snapshot/push-application-snapshot.yaml
@@ -32,7 +32,7 @@ spec:
 
           source_digest=$(skopeo inspect \
             --format '{{.Digest}}' \
-            "docker://${data[pullSpec]}" 2>/dev/null)
+            "docker://${data[containerImage]}" 2>/dev/null)
           # note: Inspection might fail on empty repos, hence `|| true`
           destination_digest=$(
             skopeo inspect \
@@ -40,17 +40,17 @@ spec:
             "docker://${data[repository]}:${data[tag]}" 2>/dev/null || true)
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]
           then
-            printf '* Pushing component: %s\n' "${data[component]}"
+            printf '* Pushing component: %s\n' "${data[name]}"
             skopeo copy \
               --all \
               --preserve-digests \
               --dest-precompute-digests \
               --retry-times="$(params.retries)" \
-              "docker://${data[pullSpec]}" \
+              "docker://${data[containerImage]}" \
               "docker://${data[repository]}:${data[tag]}" ;
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
-              "${data[component]}" "$source_digest"
+              "${data[name]}" "$source_digest"
           fi
-        done < <(jq -rc '.images[]' <<<'$(params.mappedApplicationSnapshot)')
+        done < <(jq -rc '.components[]' <<<'$(params.mappedApplicationSnapshot)')
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"


### PR DESCRIPTION
We are moving from the proof of concept ApplicationSnapshot CRD to
the production one maintained by the GitOps team. This commit changes
field names to reflect the names used in the GitOps CRD.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>