### PR TITLE
fix: use shared git-clone task

### DIFF
--- a/definitions/m5-release-pipeline/m5-release-pipeline.yaml
+++ b/definitions/m5-release-pipeline/m5-release-pipeline.yaml
@@ -33,7 +33,7 @@ spec:
     - name: clone-config-file
       taskRef:
         name: git-clone
-        bundle: quay.io/hacbs-release/git-clone:main
+        bundle: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
       when:
         - input: $(params.extraConfigGitUrl)
           operator: notin


### PR DESCRIPTION
For demo time crunch purposes, we copied the git-clone task into our own bundle
and used it in the milestone 5 release pipeline. We should use the shared one
from redhat-appstudio. This commit switches to it.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>