### PR TITLE
feat: Introduce changed-files GitHub action.

### DIFF
--- a/.github/scripts/tkn_push_bundles.sh
+++ b/.github/scripts/tkn_push_bundles.sh
@@ -4,20 +4,11 @@ printf 'Gathering new/modified bundle definitions.\n'
 
 # Gather new/modified bundle definitions.
 declare -A bundle_dirs  # associative array to hash bundle dirs in key space.
-while read file
+for file in ${ALL_CHANGED_FILES}
 do
-  # Only match yaml files in bundle dirs within definitions dir.
-  if [[ $file =~ .*[-,_]{2,} ]]
-  then
-    printf 'NO consecutive hyphen or underscores allowed: %s\n' "$file"
-  elif [[ ${file} =~ ^("./")?"definitions/"[a-z,A-Z,0-9,_-]+"/"[a-z,A-Z,0-9,_-]+".yaml"$ ]]
-  then
-    printf 'MATCHED: %s\n' "$file"
-    bundle_dirs["${file%/*}"]=""  # hash the bundle dir
-  else
-    printf 'NO MATCH: %s\n' "$file"
-  fi
-done < <(git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA})
+  printf 'MATCHED: %s\n' "$file"
+  bundle_dirs["${file%/*}"]=""  # hash the bundle dir
+done
 # EO gathering changed definitions
 printf 'bundle_dirs: %s\n' "${!bundle_dirs[@]}"
 

--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -3,6 +3,7 @@ name: Tekton Bundle Push
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ['main']
+    paths: ['definitions/*/*.yaml']
   workflow_dispatch:
 env:
   IMAGE_REGISTRY: quay.io
@@ -17,7 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 2  # using git diff-tree requires fetch depth=2
+          fetch-depth: 0  # ∈(2,0) where 0 = all history, and 2 is the minimum.
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v22.2
+        with:
+          files: |
+            definitions/*/*.yaml
       - name: Create mock kube config
         run: .github/scripts/mock_kube_config.sh
         shell: bash
@@ -31,6 +38,7 @@ jobs:
         run: .github/scripts/tkn_push_bundles.sh
         shell: bash
         env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REFNAME: ${{ github.ref_name }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This push happens automatically whenever a new bundle is added to the repository
 tags will be created or updated during this automatic process:
 
 * **main**: This tag will point always to the existing code in the repository main branch.
-* **commit-sha**: A tag with the commit-sha of the change will be created, so we can have multiple bundles per each
+* **<commit-sha>**: A tag with the commit-sha of the change will be created, so we can have multiple bundles per each
 change in the git repository.
 
 ## Adding new bundles


### PR DESCRIPTION
Remarks:
* Add "changed-files" action to CI workflow
* Configure action to diff  "definitons/*/*.yaml" files
* Update shell script use changed-files as input.
* Added `on: path` [workflow filter pattern](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) to ONLY run when bundle definitions are part of the push.
* Accordingly, removed redundant path checking REGEX from the script.

This should allow the repo to re-enable merge-commits.

Jira: hacbs-692

Signed-off-by: Jon Disnard <jdisnard@redhat.com>