### PR TITLE
fix(HACBS-667): fix syntax typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This push happens automatically whenever a new bundle is added to the repository
 tags will be created or updated during this automatic process:
 
 * **main**: This tag will point always to the existing code in the repository main branch.
-* **<commit-sha>**: A tag with the commit-sha of the change will be created, so we can have multiple bundles per each
+* **commit-sha**: A tag with the commit-sha of the change will be created, so we can have multiple bundles per each
 change in the git repository.
 
 ## Adding new bundles


### PR DESCRIPTION
It seems that text between `< >` is not showed by Markdown. I'm removing that as part of this commit.

Signed-off-by: David Moreno García <damoreno@redhat.com>