### PR TITLE
chore(hacbs-1075): update YAML definitions to trigger CI bundle push

### DIFF
--- a/catalog/pipeline/release/0.1/release.yaml
+++ b/catalog/pipeline/release/0.1/release.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton pipeline to release HACBS Application Snapshot to Quay

--- a/catalog/pipeline/release/0.2/release.yaml
+++ b/catalog/pipeline/release/0.2/release.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton pipeline to release HACBS Application Snapshot to Quay

--- a/catalog/task/apply-mapping/0.1/apply-mapping.yaml
+++ b/catalog/task/apply-mapping/0.1/apply-mapping.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton task to apply a mapping to an Application Snapshot

--- a/catalog/task/cleanup-workspace/0.1/cleanup-workspace.yaml
+++ b/catalog/task/cleanup-workspace/0.1/cleanup-workspace.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton task to delete a given directory in a passed workspace

--- a/catalog/task/prepare-validation/0.1/prepare-validation.yaml
+++ b/catalog/task/prepare-validation/0.1/prepare-validation.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton task to extract a pull spec from an Application Snapshot

--- a/catalog/task/push-application-snapshot/0.1/push-application-snapshot.yaml
+++ b/catalog/task/push-application-snapshot/0.1/push-application-snapshot.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton task to push snapshot images to an image registry using `skopeo copy`

--- a/catalog/task/skopeo-copy/0.1/skopeo-copy.yaml
+++ b/catalog/task/skopeo-copy/0.1/skopeo-copy.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
 spec:
   description: >-
     Tekton task that pushes container images to a registry using `skopeo copy`


### PR DESCRIPTION
This adds a trivial annotation to YAML definitions to force CI. Normally CI will update bundles only when they have been updated. For lack of a way to manually trigger the CI, hence the commit.

The trivial update here is adding a "release" tag to the ones managed by the release team.

Signed-off-by: Jon Disnard <jdisnard@redhat.com>