### PR TITLE
chore(hacbs-1077): add boilerplate task & pipeline runs for test

### DIFF
--- a/catalog/pipeline/release/0.1/tests/run.yaml
+++ b/catalog/pipeline/release/0.1/tests/run.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: applicationSnapshot
+      value: ""
+    - name: policy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: release
+    bundle: quay.io/hacbs-release/pipeline-release:0.1

--- a/catalog/pipeline/release/0.2/tests/run.yaml
+++ b/catalog/pipeline/release/0.2/tests/run.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: release-run-empty-params
+spec:
+  params:
+    - name: applicationSnapshot
+      value: ""
+    - name: policy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: release
+    bundle: quay.io/hacbs-release/pipeline-release:0.2

--- a/catalog/task/apply-mapping/0.1/tests/run.yaml
+++ b/catalog/task/apply-mapping/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: apply-mapping-run-empty-params
+spec:
+  params:
+    - name: subdirectory
+      value: ""
+  taskRef:
+    name: apply-mapping
+    bundle: quay.io/hacbs-release/task-apply-mapping:0.1

--- a/catalog/task/cleanup-workspace/0.1/tests/run.yaml
+++ b/catalog/task/cleanup-workspace/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: cleanup-workspace-run-empty-params
+spec:
+  params:
+    - name: subdirectory
+      value: ""
+  taskRef:
+    name: cleanup-workspace
+    bundle: quay.io/hacbs-release/task-cleanup-workspace:0.1

--- a/catalog/task/prepare-validation/0.1/tests/run.yaml
+++ b/catalog/task/prepare-validation/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: prepare-validation-run-empty-params
+spec:
+  params:
+    - name: applicationSnapshot
+      value: ""
+  taskRef:
+    name: prepare-validation
+    bundle: quay.io/hacbs-release/task-prepare-validation:0.1

--- a/catalog/task/push-application-snapshot/0.1/tests/run.yaml
+++ b/catalog/task/push-application-snapshot/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: push-application-snapshot-run-empty-params
+spec:
+  params:
+    - name: mappedApplicationSnapshot
+      value: ""
+  taskRef:
+    name: push-application-snapshot
+    bundle: quay.io/hacbs-release/task-push-application-snapshot:0.1

--- a/catalog/task/skopeo-copy/0.1/tests/run.yaml
+++ b/catalog/task/skopeo-copy/0.1/tests/run.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-copy-run-empty-params
+spec:
+  params:
+    - name: srcImageURL
+      value: ""
+    - name: destImageURL
+      value: ""
+    - name: srcToken
+      value: ""
+    - name: destToken
+      value: ""
+    - name: retries
+      value: ""
+  taskRef:
+    name: skopeo-copy
+    bundle: quay.io/hacbs-release/task-skopeo-copy:0.1


### PR DESCRIPTION
* Each pipeline & task version was given a boilerplate run.yaml
* These could also potentially serve as the sample runs
* The idea is tests will become more elaborate later

Signed-off-by: Jon Disnard <jdisnard@redhat.com>