### PR TITLE
bug(hacbs-1135): stop applying extra tags on bundle push

### DIFF
--- a/.github/scripts/tkn_push_bundles.sh
+++ b/.github/scripts/tkn_push_bundles.sh
@@ -62,14 +62,6 @@ do
       --data "$new_repo_string"
   fi
 
-  # Tag with git commit sha hex
-  printf 'Pushing image to repo: %s:%s\n' "$image_string" "${GITHUB_SHA:0:7}"
-  tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${GITHUB_SHA:0:7}"
-
-  # Tag with git branch string
-  printf 'Pushing image to repo: %s:%s\n' "$image_string" "${GITHUB_REFNAME}"
-  tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${GITHUB_REFNAME}"
-
   # Tag with version dir string
   printf 'Pushing image to repo: %s:%s\n' "$image_string" "${4}"
   tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${4}"

--- a/.github/scripts/tkn_push_bundles.sh
+++ b/.github/scripts/tkn_push_bundles.sh
@@ -66,4 +66,9 @@ do
   printf 'Pushing image to repo: %s:%s\n' "$image_string" "${4}"
   tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${4}"
 
+  # Tag with catalog version + git commit sha hex
+  # {catalog_version}-{commit_sha1}
+  printf 'Pushing image to repo: %s:%s\n' "$image_string" "${4}-${GITHUB_SHA:0:7}"
+  tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${4}-${GITHUB_SHA:0:7}"
+
 done


### PR DESCRIPTION
* The image repo does not allow tag for multiple imgages.
* we decided to stop having git branch & sha1 tags.
* we will use catalog version tags, image digests, or both.

Signed-off-by: Jon Disnard <jdisnard@redhat.com>