### PR TITLE
fix: changes enterpriseContractPolicy to camel-case

### DIFF
--- a/catalog/pipeline/release/0.3/README.md
+++ b/catalog/pipeline/release/0.3/README.md
@@ -21,7 +21,7 @@ Tekton pipeline to release HACBS Application Snapshot to Quay.
   * Task `verify-enterprise-contract` was changed
     * Task parameter `POLICY_CONFIGURATION` value was changed
       * old: $(params.policy)
-      * new: $(params.enterprisecontractpolicy)
+      * new: $(params.enterpriseContractPolicy)
 
 ## Changes since 0.1 (milestone-5)
 

--- a/catalog/pipeline/release/0.3/release.yaml
+++ b/catalog/pipeline/release/0.3/release.yaml
@@ -15,7 +15,7 @@ spec:
     - name: applicationSnapshot
       type: string
       description: The ApplicationSnapshot in JSON format
-    - name: enterprisecontractpolicy
+    - name: enterpriseContractPolicy
       type: string
       description: JSON representation of the EnterpriseContractPolicy
     - name: extraConfigGitUrl
@@ -81,7 +81,7 @@ spec:
         - name: SSL_CERT_DIR
           value: /var/run/secrets/kubernetes.io/serviceaccount
         - name: POLICY_CONFIGURATION
-          value: $(params.enterprisecontractpolicy)
+          value: $(params.enterpriseContractPolicy)
         - name: STRICT
           value: "0"
     - name: push-application-snapshot

--- a/catalog/pipeline/release/0.3/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/release/0.3/samples/sample_release_PipelineRun.yaml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: applicationSnapshot
       value: ""
-    - name: enterprisecontractpolicy
+    - name: enterpriseContractPolicy
       value: ""
     - name: extraConfigGitUrl
       value: ""

--- a/catalog/pipeline/release/0.3/tests/run.yaml
+++ b/catalog/pipeline/release/0.3/tests/run.yaml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: applicationSnapshot
       value: ""
-    - name: enterprisecontractpolicy
+    - name: enterpriseContractPolicy
       value: ""
     - name: extraConfigGitUrl
       value: ""


### PR DESCRIPTION
Changes `enterprisecontractpolicy` pipeline parameter to `enterpriseContractPolicy` 
keeping the stardard camel case format.

Change depends on: https://github.com/redhat-appstudio/release-service/pull/123