### PR TITLE
feat(hacbs_1267): adds new FBC PipelineRun bundle

### DIFF
--- a/catalog/pipeline/fbc-release/0.1/README.md
+++ b/catalog/pipeline/fbc-release/0.1/README.md
@@ -1,0 +1,16 @@
+# FBC Release Pipeline
+
+FBC Release Pipeline
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the EnterpriseContractPolicy | No | - |
+| fbcFragment | FBC fragment built by HACBS | No | - |
+| fromIndex | Index image (catalog of catalogs) the FBC fragment will be added to | No | - |
+| overWriteFromIndex | Boolean indicating if the fromIndex should be overwritten | Yes | - |
+| binaryImage | OCP binary image to be baked into the index image | Yes | - |
+| buildTags | List of additional tags the internal index image copy should be tagged with | Yes | - |
+| addArches | List of arches the index image should be built for | Yes | - |

--- a/catalog/pipeline/fbc-release/0.1/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.1/fbc-release.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: bundle-fbc-release-pipelinerun
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton release pipeline to interact with FBC Pipeline
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: fbcFragment
+      type: string
+      description: FBC fragment built by HACBS
+    - name: fromIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to
+    - name: overwriteFromIndex
+      type: string
+      description: Boolean indicating if the fromIndex should be overwritten
+    - name: binaryImage
+      type: string
+      description: OCP binary image to be baked into the index image
+    - name: buildTags
+      type: string
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      description: List arches to be added to be built
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: verify-enterprise-contract
+      taskRef:
+        name: verify-enterprise-contract-v2
+        bundle: quay.io/hacbs-release/verify-enterprise-contract-v2:main
+      params:
+        - name: IMAGES
+          value: $(params.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "0"
+    - name: create-internal-request
+      taskRef:
+        name: create-internal-request
+        bundle: quay.io/hacbs-release/task-create-internal-request:0.1
+      params:
+        - name: pipelineRunName
+          value: $(context.pipelineRun.name)
+        - name: fbcFragment
+          value: $(params.fbcFragment)
+        - name: fromIndex
+          value: $(params.fromIndex)
+        - name: overwriteFromIndex
+          value: $(params.overwriteFromIndex)
+        - name: binaryImage
+          value: $(params.binaryImage)
+        - name: buildTags
+          value: $(params.buildTags)
+        - name: addArches
+          value: $(params.addArches)

--- a/catalog/pipeline/fbc-release/0.1/samples/sample_release_PipelineRun.yaml
+++ b/catalog/pipeline/fbc-release/0.1/samples/sample_release_PipelineRun.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fbcFragment
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: overwriteFromIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: buildArches
+      value: ""
+  pipelineRef:
+    name: fbc-release
+    bundle: quay.io/hacbs-release/pipeline-fbc-release:0.1

--- a/catalog/pipeline/fbc-release/0.1/tests/run.yaml
+++ b/catalog/pipeline/fbc-release/0.1/tests/run.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: fbc-release-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: fbcFragment
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: overwriteFromIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: buildArches
+      value: ""
+  pipelineRef:
+    name: fbc-release
+    bundle: quay.io/hacbs-release/pipeline-fbc-release:0.1

--- a/catalog/task/create-internal-request/0.1/README.md
+++ b/catalog/task/create-internal-request/0.1/README.md
@@ -1,0 +1,15 @@
+# create-internal-request
+
+Creates an InternalRequest resource to call IIB service
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| pipelineRunName | The name of the Parent PipelineRun for this task | No | `ir-$(context.pipelineRun.name)` |
+| fbcFragment | `fbcFragment` built by HACBS | No | |
+| fromIndex | `fromIndex` image (catalog of catalogs) the fbcFragment will be added to | Yes | |
+| overwriteFromIndex | Boolean indicating if the `fromIndex` should be overwritten | Yes | |
+| binaryImage | OCP `binaryImage` to be baked into the `fromIndex` image | Yes | |
+| buildTags | List of additional `buildTags` the internal `fromIndex` image copy should be tagged with | Yes | |
+| buildArches | List of `buildArches` the `fromIndex` should be built for | Yes | |

--- a/catalog/task/create-internal-request/0.1/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.1/create-internal-request.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-internal-request
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+      Creates an InternalRequest resource to call IIB service
+  params:
+    - name: pipelineRunName
+      type: string
+      description: The name of the Parent PipelineRun of this task
+    - name: binaryImage
+      type: string
+      description: FBC Image to be added to index image
+    - name: fbcFragment
+      type: string
+      description: FBC fragment built by HACBS
+    - name: fromIndex
+      type: string
+      description: Index image (catalog of catalogs) the FBC fragment will be added to    
+    - name: overwriteFromIndex
+      type: string
+      description: Boolean indicating if the fromIndex should be overwritten
+    - name: buildTags
+      type: string
+      description: List of additional tags the internal index image copy should be tagged with
+    - name: addArches
+      type: string
+      description: List of arches the index image should be built for
+  steps:
+    - name: create-internal-request
+      image: quay.io/hacbs-release/release-utils@sha256:53d4cdd2ff8d1a0c6d1781d754678b4c61e6fefa644c17bd0a4e2ca4336a3e18
+      script: |
+        #!/usr/bin/env sh
+        PATH=/bin:/usr/bin:/usr/local/bin
+        export PATH
+
+        resourceRequest="/tmp/$$"
+        cat > ${resourceRequest} <<YAML
+        ---
+        apiVersion: appstudio.redhat.com/v1alpha1
+        kind: InternalRequest
+        metadata:
+          name: "ir-$(params.pipelineRunName)"
+        spec:
+          request: "ir-$(params.pipelineRunName)"
+          params:
+            binaryImage: `printf "%q" '$(params.binaryImage)'`
+            fbcFragment: $(params.fbcFragment)
+            fromIndex: $(params.fromIndex)
+            overwriteFromIndex: $(params.overwriteFromIndex)
+            buildTags: `printf "%q" '$(params.buildTags)'`
+            addArches: `printf "%q" '$(params.addArches)'`
+        YAML
+        kubectl create -f ${resourceRequest}

--- a/catalog/task/create-internal-request/0.1/samples/sample_create-internal-request_TaskRun.yaml
+++ b/catalog/task/create-internal-request/0.1/samples/sample_create-internal-request_TaskRun.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: fbcFragment
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: overwriteFromIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: buildArches
+      value: ""
+  taskRef:
+    name: create-internal-request
+    bundle: quay.io/hacbs-release/task-create-internal-request:0.1

--- a/catalog/task/create-internal-request/0.1/tests/run.yaml
+++ b/catalog/task/create-internal-request/0.1/tests/run.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-internal-request-run-empty-params
+spec:
+  params:
+    - name: pipelineRunName
+      value: ""
+    - name: fbcFragment
+      value: ""
+    - name: fromIndex
+      value: ""
+    - name: overwriteFromIndex
+      value: ""
+    - name: binaryImage
+      value: ""
+    - name: buildTags
+      value: ""
+    - name: buildArches
+      value: ""
+  taskRef:
+    name: create-internal-request
+    bundle: quay.io/hacbs-release/task-create-internal-request:0.1

--- a/catalog/task/create-internal-request/OWNERS
+++ b/catalog/task/create-internal-request/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
Replaces https://github.com/hacbs-release/release-bundles/pull/54

Adds new Pipelines for Release FBC components.

- adds FBC Release Pipeline
- adds create-internal-request task
  
Signed-off-by: Leandro Mendes <lmendes@redhat.com>