### PR TITLE
chore: add kubectl to release-utils image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq &&\
     curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
-    chmod +x /usr/bin/jq /usr/bin/yq
+    curl -L https://dl.k8s.io/release/v1.25.0/bin/linux/amd64/kubectl -o /usr/bin/kubectl &&\
+    chmod +x /usr/bin/jq /usr/bin/yq /usr/bin/kubectl
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     git \


### PR DESCRIPTION
- adds `kubectl` to the release-utils image so we can pin the version for the dependent tasks.

PR: https://github.com/hacbs-release/release-bundles/pull/57

Signed-off-by: Leandro Mendes <lmendes@redhat.com>