### PR TITLE
feat(HACBS-1259): add skopeo-inspect task

### DIFF
--- a/catalog/task/skopeo-inspect/0.1/README.md
+++ b/catalog/task/skopeo-inspect/0.1/README.md
@@ -1,0 +1,29 @@
+# skopeo-inspect
+
+Tekton task that executes `skopeo inspect` on an image and saves the result.
+
+The output is saved to the `skopeo-inspect.json` file in the mounted workspace.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| imageURL | Image URL | No | - |
+
+## Example usage
+
+This is an example usage of the `skopeo-inspect` task:
+
+```
+---
+tasks:
+  - name: skopeo-inspect
+    taskRef:
+      name: skopeo-inspect
+    params:
+      - name: imageURL
+        value: 'docker://quay.io/hacbs-release/release-utils:latest'
+    workspaces:
+      - name: output
+        workspace: output_workspace
+```

--- a/catalog/task/skopeo-inspect/0.1/samples/sample_skopeo-inspect_TaskRun.yaml
+++ b/catalog/task/skopeo-inspect/0.1/samples/sample_skopeo-inspect_TaskRun.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-inspect-run-empty-params
+spec:
+  params:
+    - name: imageURL
+      value: ""
+  taskRef:
+    name: skopeo-inspect
+    bundle: quay.io/hacbs-release/task-skopeo-inspect:0.1

--- a/catalog/task/skopeo-inspect/0.1/skopeo-inspect.yaml
+++ b/catalog/task/skopeo-inspect/0.1/skopeo-inspect.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-inspect
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that executes `skopeo inspect` on an image and saves the result
+  params:
+    - name: imageURL
+      description: Image URL to inspect
+      type: string
+  workspaces:
+    - name: output
+      description: The workspace to place the skopeo-inspect.json file in
+  steps:
+    - name: skopeo-inspect
+      image: quay.io/skopeo/stable:v1.7.0
+      script: |
+        if [[ -z "$(params.imageURL)" ]]
+        then
+          exit 1
+        fi
+
+        skopeo inspect --no-tags "$(params.imageURL)" > $(workspaces.output.path)/skopeo-inspect.json

--- a/catalog/task/skopeo-inspect/0.1/tests/run.yaml
+++ b/catalog/task/skopeo-inspect/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-inspect-run-empty-params
+spec:
+  params:
+    - name: imageURL
+      value: ""
+  taskRef:
+    name: skopeo-inspect
+    bundle: quay.io/hacbs-release/task-skopeo-inspect:0.1

--- a/catalog/task/skopeo-inspect/OWNERS
+++ b/catalog/task/skopeo-inspect/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This commit adds a task to the catalog that executes skopeo-inspect on the passed image and saves the output to a file in the mounted workspace.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>