### PR TITLE
fix: replace push-snapshot url task to correct one

### DIFF
--- a/catalog/pipeline/release/0.4/release.yaml
+++ b/catalog/pipeline/release/0.4/release.yaml
@@ -87,7 +87,7 @@ spec:
     - name: push-snapshot
       taskRef:
         name: push-snapshot
-        bundle: quay.io/hacbs-release/push-snapshot:main
+        bundle: quay.io/hacbs-release/task-push-snapshot:main
       params:
         - name: mappedSnapshot
           value: $(tasks.apply-mapping.results.snapshot)


### PR DESCRIPTION
Replacing the url of task push-snapshot to the correct one in default release pipeline 