### PR TITLE
fix: missing quotes to preserve string type

### DIFF
--- a/catalog/task/create-internal-request/0.1/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.1/create-internal-request.yaml
@@ -54,7 +54,7 @@ spec:
             binaryImage: `printf "%q" '$(params.binaryImage)'`
             fbcFragment: $(params.fbcFragment)
             fromIndex: $(params.fromIndex)
-            overwriteFromIndex: $(params.overwriteFromIndex)
+            overwriteFromIndex: "$(params.overwriteFromIndex)"
             buildTags: `printf "%q" '$(params.buildTags)'`
             addArches: `printf "%q" '$(params.addArches)'`
         YAML


### PR DESCRIPTION
- adds missing quotes on `overwriteFromIndex` param value to preserve its type.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>