### PR TITLE
feat(hacbs-1325): adds step to check InternalRequest state and updating parameters

### DIFF
--- a/catalog/pipeline/fbc-release/0.2/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.2/fbc-release.yaml
@@ -36,8 +36,18 @@ spec:
     - name: addArches
       type: string
       description: List arches to be added to be built
+    - name: requestUpdateTimeout
+      type: string
+      description: Max seconds to wait until the status is updated
   workspaces:
     - name: release-workspace
+  results:
+    - name: requestMessage
+      value: $(tasks.create-internal-request.results.requestMessage)
+    - name: requestReason
+      value: $(tasks.create-internal-request.results.requestReason)
+    - name: requestResults
+      value: $(tasks.create-internal-request.results.requestResults)
   tasks:
     - name: verify-enterprise-contract
       taskRef:
@@ -71,3 +81,5 @@ spec:
           value: $(params.buildTags)
         - name: addArches
           value: $(params.addArches)
+        - name: requestUpdateTimeout
+          value: $(params.requestUpdateTimeout)

--- a/catalog/task/create-internal-request/0.1/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.1/create-internal-request.yaml
@@ -33,9 +33,21 @@ spec:
     - name: addArches
       type: string
       description: List of arches the index image should be built for
+    - name: requestUpdateTimeout
+      type: string
+      default: "360"
+      description: Max seconds waiting for the status update
+  results:
+    - name: requestMessage
+      description: Internal Request message
+    - name: requestReason
+      description: Internal Request reason
+    - name: requestResults
+      description: Internal Request results
   steps:
     - name: create-internal-request
-      image: quay.io/hacbs-release/release-utils@sha256:53d4cdd2ff8d1a0c6d1781d754678b4c61e6fefa644c17bd0a4e2ca4336a3e18
+      image: 
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
       script: |
         #!/usr/bin/env sh
         PATH=/bin:/usr/bin:/usr/local/bin
@@ -49,7 +61,7 @@ spec:
         metadata:
           name: "ir-$(params.pipelineRunName)"
         spec:
-          request: "ir-$(params.pipelineRunName)"
+          request: "iib"
           params:
             binaryImage: `printf "%q" '$(params.binaryImage)'`
             fbcFragment: $(params.fbcFragment)
@@ -59,3 +71,38 @@ spec:
             addArches: `printf "%q" '$(params.addArches)'`
         YAML
         kubectl create -f ${resourceRequest}
+    - name: watch-internal-request-status
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
+      script: |
+        #!/usr/bin/env sh
+        PATH=/bin:/usr/bin:/usr/local/bin
+        TASKRUN="/tmp/$$.sh"
+
+        cat > ${TASKRUN} <<SH
+        #!/usr/bin/env sh
+        IR="ir-$(params.pipelineRunName)"
+        while true; do
+          STATUS=\$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}')
+          case "\${STATUS}" in
+            True | False )
+              kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].reason}' \
+              | tee $(results.requestReason.path)
+              kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].message}' \
+              | tee $(results.requestMessage.path)
+              kubectl get internalrequest \${IR} -o jsonpath='{.status.results}' | jq -R \
+              | tee $(results.requestResults.path)
+              break
+              ;;
+            "*")
+              ;;
+          esac
+          sleep 5
+        done
+        [ \$(kubectl get internalrequest \${IR} -o jsonpath='{.status.conditions[0].status}') == "True" ]
+        SH
+        chmod +x ${TASKRUN}
+        timeout $(params.requestUpdateTimeout) ${TASKRUN}
+        SYSEXIT=$?
+        [ ${SYSEXIT} -eq 124 ] && echo "Timeout while waiting for the internal request update"
+        exit ${SYSEXIT}


### PR DESCRIPTION
The InternalRequest CR already can be created but the tasks and pipeline need changes to be able to watch the InternalRequest state.

- adds `watch-internal-request-status` step
- adds `requestUpdateTimeout` param to fbc-release
- adds `results` to pipeline and tasks

Signed-off-by: Leandro Mendes <lmendes@redhat.com>