### PR TITLE
feat(HACBS-1635): change base image name to release-base-image

### DIFF
--- a/.github/workflows/dockerfile_push.yaml
+++ b/.github/workflows/dockerfile_push.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       QUAY_ORG: hacbs-release
-      QUAY_REPO: release-utils
+      QUAY_REPO: release-base-image
     steps:
       - name: Check out source code
         uses: actions/checkout@v2


### PR DESCRIPTION
I'll update the tasks in the next PR - I want the image to exist first