### PR TITLE
feat(HACBS-1261): add task to create image in pyxis

### DIFF
--- a/catalog/task/create-pyxis-image/0.1/README.md
+++ b/catalog/task/create-pyxis-image/0.1/README.md
@@ -1,0 +1,18 @@
+# create-pyxis-image
+
+Tekton task that executes a python script to push a container image's metadata to Pyxis.
+The task expects a workspace to be mounted containing a file with the `skopeo inspect` output of the
+container that will have its metadata uploaded to Pyxis.
+
+The ID of the created `containerImage` is stored as a task result.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| server | The server type to use. Options are 'production' and 'stage' | No | production |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
+| certified | If set to true, the image will be marked as certified in its Pyxis entry | No | false |
+| tag | The tag to use when pushing the container image metadata to Pyxis | No | - |
+| isLatest | If set to true, the image will have a latest tag added with its pyxis entry | No | false |
+| skopeoInspectFile | The filename of the saved skopeo inspect output stored on the input workspace | No | skopeo-inspect.json |

--- a/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
+++ b/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-pyxis-image
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that executes a python script to push a container image's metadata to Pyxis
+  params:
+    - name: server
+      type: string
+      description: The server type to use. Options are 'production' and 'stage'
+      default: production
+    - name: pyxisSecret
+      type: string
+      description: The kubernetes secret to use to authenticate to Pyxis
+    - name: certified
+      type: string
+      description: If set to true, the image will be marked as certified in its Pyxis entry
+      default: "false"
+    - name: tag
+      type: string
+      description: The tag to use when pushing the container image metadata to Pyxis
+    - name: isLatest
+      type: string
+      description: If set to true, the image will have a latest tag added with its Pyxis entry
+      default: "false"
+    - name: skopeoInspectFile
+      type: string
+      description: The filename of the saved skopeo inspect output stored on the input workspace
+      default: "skopeo-inspect.json"
+  results:
+    - name: containerImageID
+      description: ID of the created entry in Pyxis
+  workspaces:
+    - name: input
+      description: The workspace where the skopeoInspectFile is located
+  steps:
+    - name: create-pyxis-image
+      image:
+        quay.io/hacbs-release/release-utils@TODO
+      env:
+        - name: pyxisCert
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: cert
+        - name: pyxisKey
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: key
+      script: |
+        #!/usr/bin/env sh
+        set -o pipefail
+
+        if [[ "$(params.server)" == "production" ]]
+        then
+          PYXIS_URL="https://pyxis.api.redhat.com/"
+        elif [[ "$(params.server)" == "stage" ]]
+        then
+          PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
+        else
+          echo "Invalid server parameter. Only 'production' and 'stage' are allowed."
+          exit 1
+        fi
+
+        echo "${pyxisCert}" > /tmp/crt
+        echo "${pyxisKey}" > /tmp/key
+
+        PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
+          --pyxis-url $PYXIS_URL \
+          --certified $(params.certified) \
+          --tag $(params.tag) \
+          --is-latest $(params.isLatest) \
+          --verbose \
+          --skopeo-result $(workspaces.input.path)/$(params.skopeoInspectFile) | tee /tmp/output
+
+        grep 'The image id is' /tmp/output | awk '{print $NF}' > $(results.containerImageID.path)

--- a/catalog/task/create-pyxis-image/0.1/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.1/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-pyxis-image-run-empty-params
+spec:
+  params:
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+  taskRef:
+    name: create-pyxis-image
+    bundle: quay.io/hacbs-release/task-create-pyxis-image:0.1

--- a/catalog/task/create-pyxis-image/0.1/tests/run.yaml
+++ b/catalog/task/create-pyxis-image/0.1/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-pyxis-image-run-empty-params
+spec:
+  params:
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+  taskRef:
+    name: create-pyxis-image
+    bundle: quay.io/hacbs-release/task-create-pyxis-image:0.1

--- a/catalog/task/create-pyxis-image/OWNERS
+++ b/catalog/task/create-pyxis-image/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This commit adds a tekton task to the catalog that pushes metadata to pyxis to create a containerImage entry.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>