### PR TITLE
feat(HACBS-1262): add prepare-skopeo-image-string task

### DIFF
--- a/catalog/task/prepare-skopeo-image-string/0.1/README.md
+++ b/catalog/task/prepare-skopeo-image-string/0.1/README.md
@@ -1,0 +1,28 @@
+# prepare-skopeo-image-string
+
+Tekton task to create a string from a snapshot that can be passed to skopeo.
+
+The purpose of this task is to create a string that can be passed as an argument to skopeo inspect.
+The task creates this string by extracting the containerImage value from the snapshot provided and
+prepending 'docker://' to it.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format containing a single container image | No | - |
+
+## Example usage
+
+This is an example usage of the `prepare-skopeo-image-string` task:
+
+```
+---
+tasks:
+  - name: prepare-skopeo-image-string
+    taskRef:
+      name: prepare-skopeo-image-string
+    params:
+      - name: snapshot
+        value: '{"components":[{"name":"component1","containerImage":"quay.io/repo/component1:digest"}]}'
+```

--- a/catalog/task/prepare-skopeo-image-string/0.1/prepare-skopeo-image-string.yaml
+++ b/catalog/task/prepare-skopeo-image-string/0.1/prepare-skopeo-image-string.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: prepare-skopeo-image-string
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to create a string from a snapshot that can be passed to skopeo
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format containing a single container image
+  results:
+    - name: skopeoImageString
+      description: |
+        The container image extracted from the snapshot, prepended by docker://
+  steps:
+    - name: apply-mapping
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
+      script: |
+        #!/usr/bin/env sh
+        set -eux
+
+        echo "docker://"$(jq '.components[0].containerImage' <<< '$(params.snapshot)' | cut -d '"' -f 2) | \
+            tee $(results.skopeoImageString.path)

--- a/catalog/task/prepare-skopeo-image-string/0.1/samples/sample_prepare-skopeo-image-string_TaskRun.yaml
+++ b/catalog/task/prepare-skopeo-image-string/0.1/samples/sample_prepare-skopeo-image-string_TaskRun.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: prepare-skopeo-image-string-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+  taskRef:
+    name: prepare-skopeo-image-string
+    bundle: quay.io/hacbs-release/task-prepare-skopeo-image-string:0.1

--- a/catalog/task/prepare-skopeo-image-string/0.1/tests/run.yaml
+++ b/catalog/task/prepare-skopeo-image-string/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: prepare-skopeo-image-string-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+  taskRef:
+    name: prepare-skopeo-image-string
+    bundle: quay.io/hacbs-release/task-prepare-skopeo-image-string:0.1

--- a/catalog/task/prepare-skopeo-image-string/OWNERS
+++ b/catalog/task/prepare-skopeo-image-string/OWNERS
@@ -1,0 +1,1 @@
+hacbs-release@redhat.com


### PR DESCRIPTION
This commit adds a new task named prepare-skopeo-image-string that is intended to create a string that can be passed to skopeo from a snapshot.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>