### PR TITLE
fix(HACBS-1262): cleanup bash in prepare-skopeo-image-string

### DIFF
--- a/catalog/task/prepare-skopeo-image-string/0.1/prepare-skopeo-image-string.yaml
+++ b/catalog/task/prepare-skopeo-image-string/0.1/prepare-skopeo-image-string.yaml
@@ -27,5 +27,5 @@ spec:
         #!/usr/bin/env sh
         set -eux
 
-        echo "docker://"$(jq '.components[0].containerImage' <<< '$(params.snapshot)' | cut -d '"' -f 2) | \
+        echo -n "docker://"$(jq -r '.components[0].containerImage' <<< '$(params.snapshot)') | \
             tee $(results.skopeoImageString.path)


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>