### PR TITLE
fix: wrong result name in create-pyxis-image

### DIFF
--- a/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
+++ b/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
@@ -81,5 +81,5 @@ spec:
               --verbose \
               --skopeo-result /tmp/skopeo-inspect.json | tee /tmp/output
     
-            grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageID.path)
+            grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageIDs.path)
         done


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>