### PR TITLE
fix(HACBS-1262): use mapped location in create-pyxis-image task

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.1/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.1/push-to-external-registry.yaml
@@ -113,7 +113,7 @@ spec:
           value: $(params.pyxisSecret)
         - name: tag
           value: $(params.tag)
-        - name: snapshot
+        - name: mappedSnapshot
           value: $(tasks.apply-mapping.results.snapshot)
       runAfter:
         - push-snapshot

--- a/catalog/task/create-pyxis-image/0.1/README.md
+++ b/catalog/task/create-pyxis-image/0.1/README.md
@@ -1,8 +1,8 @@
 # create-pyxis-image
 
-Tekton task that pushes metadata to Pyxis for all container images contained in a snapshot. It first extracts
-the containerImages from the snapshot, then runs `skopeo inspect` on each, before finally pushing
-metadata to Pyxis.
+Tekton task that pushes metadata to Pyxis for all container images contained in a snapshot that is the
+result of the `apply-mapping` task. It first extracts the containerImages from the snapshot, then runs
+`skopeo inspect` on each, before finally pushing metadata to Pyxis.
 
 The IDs of the created `containerImage` Pyxis objects are stored as a task result with each ID separated
 by a new line.
@@ -16,4 +16,4 @@ by a new line.
 | certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
 | tag | The tag to use when pushing the container image metadata to Pyxis | No | - |
 | isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
-| snapshot | The snapshot in JSON format | No | - |
+| mappedSnapshot | The mapped snapshot in JSON format | No | - |

--- a/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
+++ b/catalog/task/create-pyxis-image/0.1/create-pyxis-image.yaml
@@ -30,9 +30,9 @@ spec:
       type: string
       description: If set to true, the images will have a latest tag added with their Pyxis entries
       default: "false"
-    - name: snapshot
+    - name: mappedSnapshot
       type: string
-      description: The snapshot in JSON format
+      description: The mapped snapshot in JSON format
   results:
     - name: containerImageIDs
       description: IDs of the created entries in Pyxis, each on its own line
@@ -69,7 +69,7 @@ spec:
         echo "${pyxisCert}" > /tmp/crt
         echo "${pyxisKey}" > /tmp/key
 
-        for containerImage in $(jq -r '.components[].containerImage' <<< '$(params.snapshot)') ; do
+        for containerImage in $(jq -r '.components[].repository' <<< '$(params.snapshot)') ; do
 
             skopeo inspect --no-tags "docker://${containerImage}" > /tmp/skopeo-inspect.json
     

--- a/catalog/task/create-pyxis-image/0.1/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.1/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -9,7 +9,7 @@ spec:
       value: ""
     - name: tag
       value: ""
-    - name: snapshot
+    - name: mappedSnapshot
       value: ""
   taskRef:
     name: create-pyxis-image

--- a/catalog/task/create-pyxis-image/0.1/tests/run.yaml
+++ b/catalog/task/create-pyxis-image/0.1/tests/run.yaml
@@ -9,7 +9,7 @@ spec:
       value: ""
     - name: tag
       value: ""
-    - name: snapshot
+    - name: mappedSnapshot
       value: ""
   taskRef:
     name: create-pyxis-image


### PR DESCRIPTION
This commit switches the create-pyxis-image task to use the mapped location in the snapshot (repository) instead of the origin location (containerImage).

Signed-off-by: Johnny Bieren <jbieren@redhat.com>