### PR TITLE
fix: adds proper default value from Pipeline params

### DIFF
--- a/catalog/pipeline/fbc-release/0.4/fbc-release.yaml
+++ b/catalog/pipeline/fbc-release/0.4/fbc-release.yaml
@@ -26,12 +26,15 @@ spec:
       description: Boolean indicating if the fromIndex should be overwritten
     - name: binaryImage
       type: string
+      default: ""
       description: OCP binary image to be baked into the index image
     - name: buildTags
       type: string
+      default: "[]"
       description: List of additional tags the internal index image copy should be tagged with
     - name: addArches
       type: string
+      default: "[]"
       description: List arches to be added to be built
     - name: requestUpdateTimeout
       type: string

--- a/catalog/task/create-internal-request/0.1/create-internal-request.yaml
+++ b/catalog/task/create-internal-request/0.1/create-internal-request.yaml
@@ -77,8 +77,8 @@ spec:
             fbcFragment: `jq .components[0].containerImage < ${fbcComponentJson}`
             fromIndex: $(params.fromIndex)
             overwriteFromIndex: "$(params.overwriteFromIndex)"
-            buildTags: `printf "%q" '$(params.buildTags)'`
-            addArches: `printf "%q" '$(params.addArches)'`
+            buildTags: "$(params.buildTags)"
+            addArches: "$(params.addArches)"
             buildTimeoutSeconds: `printf "\"%q\"" '$(params.buildTimeoutSeconds)'`
         YAML
         kubectl create -f ${resourceRequest}


### PR DESCRIPTION
- adds proper default value for `fbc-release` pipeline params

Signed-off-by: Leandro Mendes <lmendes@redhat.com>