### PR TITLE
fix(hacbs-1829): use tag param

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.3/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.3/README.md
@@ -13,7 +13,7 @@ Tekton pipeline to push images to an external registry.
 | extraConfigPath | Path to the extra config file within the repository | No | - |
 | pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
-| tag | The tag to use when pushing the container images' metadata to Pyxis | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 
 ## Changes since 0.1

--- a/catalog/pipeline/push-to-external-registry/0.3/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.3/README.md
@@ -1,0 +1,26 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
+| tag | The tag to use when pushing the container images' metadata to Pyxis | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.1
+
+Upgrade create-pyxis-image task to version 0.2
+* correct incorrect snapshot param
+
+## Changes since 0.2
+
+push-snapshot now supports tag parameter

--- a/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: The kubernetes secret to use to authenticate to Pyxis
+    - name: tag
+      type: string
+      description: The tag to use when pushing the container images' metadata to Pyxis
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        name: git-clone
+        bundle: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        name: apply-mapping
+        bundle: quay.io/hacbs-release/task-apply-mapping:main
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        name: verify-enterprise-contract
+        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        name: push-snapshot
+        bundle: quay.io/hacbs-release/task-push-snapshot:main
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: tag
+          value: $(params.tag)
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        name: create-pyxis-image
+        bundle: quay.io/hacbs-release/task-create-pyxis-image:0.2
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+      runAfter:
+        - push-snapshot
+  finally:
+    - name: cleanup
+      taskRef:
+        name: cleanup-workspace
+        bundle: quay.io/hacbs-release/task-cleanup-workspace:main
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   name: push-to-external-registry
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -67,7 +67,7 @@ spec:
     - name: apply-mapping
       taskRef:
         name: apply-mapping
-        bundle: quay.io/hacbs-release/task-apply-mapping:main
+        bundle: quay.io/hacbs-release/task-apply-mapping:0.3
       params:
         - name: snapshot
           value: $(params.snapshot)
@@ -96,7 +96,7 @@ spec:
     - name: push-snapshot
       taskRef:
         name: push-snapshot
-        bundle: quay.io/hacbs-release/task-push-snapshot:main
+        bundle: quay.io/hacbs-release/task-push-snapshot:0.4
       params:
         - name: mappedSnapshot
           value: $(tasks.apply-mapping.results.snapshot)
@@ -123,7 +123,7 @@ spec:
     - name: cleanup
       taskRef:
         name: cleanup-workspace
-        bundle: quay.io/hacbs-release/task-cleanup-workspace:main
+        bundle: quay.io/hacbs-release/task-cleanup-workspace:0.2
       when:
         - input: $(params.postCleanUp)
           operator: in

--- a/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
@@ -38,7 +38,7 @@ spec:
       description: The kubernetes secret to use to authenticate to Pyxis
     - name: tag
       type: string
-      description: The tag to use when pushing the container images' metadata to Pyxis
+      description: The default tag to use when mapping file does not contain a tag
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/push-to-external-registry.yaml
@@ -107,7 +107,7 @@ spec:
     - name: create-pyxis-image
       taskRef:
         name: create-pyxis-image
-        bundle: quay.io/hacbs-release/task-create-pyxis-image:0.2
+        bundle: quay.io/hacbs-release/task-create-pyxis-image:0.3
       params:
         - name: server
           value: $(params.pyxisServerType)

--- a/catalog/pipeline/push-to-external-registry/0.3/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: push-to-external-registry
+    bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:0.3

--- a/catalog/pipeline/push-to-external-registry/0.3/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.3/tests/run.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: push-to-external-registry
+    bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:0.3

--- a/catalog/task/create-pyxis-image/0.3/README.md
+++ b/catalog/task/create-pyxis-image/0.3/README.md
@@ -1,0 +1,27 @@
+# create-pyxis-image
+
+Tekton task that pushes metadata to Pyxis for all container images contained in a snapshot that is the
+result of the `apply-mapping` task. It first extracts the containerImages from the snapshot, then runs
+`skopeo inspect` on each, before finally pushing metadata to Pyxis.
+
+The IDs of the created `containerImage` Pyxis objects are stored as a task result with each ID separated
+by a new line.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| server | The server type to use. Options are 'production' and 'stage' | Yes | production |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
+| certified | If set to true, the images will be marked as certified in their Pyxis entries | Yes | false |
+| tag | The tag to use when pushing the container image metadata to Pyxis | No | - |
+| isLatest | If set to true, the images will have a latest tag added with their Pyxis entries | Yes | false |
+| mappedSnapshot | The mapped snapshot in JSON format | No | - |
+
+## Changes since 0.2
+
+* Use tag present in mapping file if present.
+
+## Changes since 0.1
+
+* Fix for incorrect snapshot param.

--- a/catalog/task/create-pyxis-image/0.3/create-pyxis-image.yaml
+++ b/catalog/task/create-pyxis-image/0.3/create-pyxis-image.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-pyxis-image
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task that pushes metadata to Pyxis for all container images contained in a snapshot
+  params:
+    - name: server
+      type: string
+      description: The server type to use. Options are 'production' and 'stage'
+      default: production
+    - name: pyxisSecret
+      type: string
+      description: The kubernetes secret to use to authenticate to Pyxis
+    - name: certified
+      type: string
+      description: If set to true, the images will be marked as certified in their Pyxis entries
+      default: "false"
+    - name: tag
+      type: string
+      description: Default tag to use if mapping entry does not contain a tag
+    - name: isLatest
+      type: string
+      description: If set to true, the images will have a latest tag added with their Pyxis entries
+      default: "false"
+    - name: mappedSnapshot
+      type: string
+      description: The mapped snapshot in JSON format
+  results:
+    - name: containerImageIDs
+      description: IDs of the created entries in Pyxis, each on its own line
+  steps:
+    - name: create-pyxis-image
+      image:
+        quay.io/hacbs-release/release-utils@sha256:5298e31e7e7a97cab005750096abe8dbfca3f422cf049fd87de76a117072a9b5
+      env:
+        - name: pyxisCert
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: cert
+        - name: pyxisKey
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxisSecret)
+              key: key
+      script: |
+        #!/usr/bin/env sh
+        set -o pipefail
+
+        if [[ "$(params.server)" == "production" ]]
+        then
+          PYXIS_URL="https://pyxis.api.redhat.com/"
+        elif [[ "$(params.server)" == "stage" ]]
+        then
+          PYXIS_URL="https://pyxis.preprod.api.redhat.com/"
+        else
+          echo "Invalid server parameter. Only 'production' and 'stage' are allowed."
+          exit 1
+        fi
+
+        echo "${pyxisCert}" > /tmp/crt
+        echo "${pyxisKey}" > /tmp/key
+
+        for containerImage in $(jq -r '.components[].repository' <<< '$(params.mappedSnapshot)') ; do
+
+            skopeo inspect --no-tags "docker://${containerImage}" > /tmp/skopeo-inspect.json
+    
+            PYXIS_CERT_PATH=/tmp/crt PYXIS_KEY_PATH=/tmp/key create_container_image \
+              --pyxis-url $PYXIS_URL \
+              --certified $(params.certified) \
+              --tag $(params.tag) \
+              --is-latest $(params.isLatest) \
+              --verbose \
+              --skopeo-result /tmp/skopeo-inspect.json | tee /tmp/output
+    
+            grep 'The image id is' /tmp/output | awk '{print $NF}' >> $(results.containerImageIDs.path)
+        done

--- a/catalog/task/create-pyxis-image/0.3/samples/sample_create-pyxis-image_TaskRun.yaml
+++ b/catalog/task/create-pyxis-image/0.3/samples/sample_create-pyxis-image_TaskRun.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-pyxis-image-run-empty-params
+spec:
+  params:
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: mappedSnapshot
+      value: ""
+  taskRef:
+    name: create-pyxis-image
+    bundle: quay.io/hacbs-release/task-create-pyxis-image:0.3

--- a/catalog/task/create-pyxis-image/0.3/tests/run.yaml
+++ b/catalog/task/create-pyxis-image/0.3/tests/run.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: create-pyxis-image-run-empty-params
+spec:
+  params:
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: mappedSnapshot
+      value: ""
+  taskRef:
+    name: create-pyxis-image
+    bundle: quay.io/hacbs-release/task-create-pyxis-image:0.3

--- a/catalog/task/push-snapshot/0.4/README.md
+++ b/catalog/task/push-snapshot/0.4/README.md
@@ -4,10 +4,15 @@ Tekton task to push snapshot images to an image registry using `skopeo copy`.
 
 ## Parameters
 
-| Name | Description | Optional | Default value |
-|------|-------------|----------|---------------|
-| mappedSnapshot | JSON string representing the Snapshot | No | - |
-| retries | Retry copy N times | Yes | 0 |
+| Name           | Description                                                                                     | Optional | Default value |
+|----------------|-------------------------------------------------------------------------------------------------|----------|---------------|
+| mappedSnapshot | JSON string representing the Snapshot                                                           | No       | -             |
+| tag            | Default tag to use if mapping entry does not contain a tag | Yes     | latest        |
+| retries        | Retry copy N times                                                                              | Yes      | 0             |
+
+## Changes since 0.3
+
+* Default tag to use will default to `tag` parameter
 
 ## Changes since 0.2
 

--- a/catalog/task/push-snapshot/0.4/README.md
+++ b/catalog/task/push-snapshot/0.4/README.md
@@ -1,0 +1,23 @@
+# push-snapshot
+
+Tekton task to push snapshot images to an image registry using `skopeo copy`.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| mappedSnapshot | JSON string representing the Snapshot | No | - |
+| retries | Retry copy N times | Yes | 0 |
+
+## Changes since 0.2
+
+  * Base image was changed from `release-utils` to `release-base-image`
+
+## Changes since 0.1 (milestone-8)
+
+  * Task `samples/sample_push-application-snapshot_TaskRun.yaml` was renamed to `samples/sample_push-snapshot_TaskRun.yaml`
+  * Task `push-application-snapshot` was renamed to `push-snapshot`
+  * Task `push-snapshot` was changed
+    * Task parameter `mappedApplicationSnapshot` value was changed
+      * old: $(params.mappedApplicationSnapshot)
+      * new: $(params.mappedSnapshot)

--- a/catalog/task/push-snapshot/0.4/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.4/push-snapshot.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: push-snapshot
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to push snapshot images to an image registry using `skopeo copy`
+  params:
+    - name: mappedSnapshot
+      description: JSON string representing the Snapshot
+      type: string
+    - name: tag
+      description: tag name to create on external registry
+      type: string
+      default: "latest"
+    - name: retries
+      description: Retry copy N times.
+      type: string
+      default: "0"
+  steps:
+    - name: skopeo-copy
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+        application=$(jq -r '.application' <<<'$(params.mappedSnapshot)')
+        printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
+        while read line;
+        do
+          # Create array with component values
+          typeset -A data
+          while IFS== read -r key value; do
+            data["$key"]="$value"
+          done < <(jq -r '. | to_entries | .[] | .key + "=" + .value' <<<"$line")
+          data[tag]="${data[tag]:=$(params.tag)}"
+          typeset -p data
+
+          source_digest=$(skopeo inspect \
+            --format '{{.Digest}}' \
+            "docker://${data[containerImage]}" 2>/dev/null)
+          # note: Inspection might fail on empty repos, hence `|| true`
+          destination_digest=$(
+            skopeo inspect \
+            --format '{{.Digest}}' \
+            "docker://${data[repository]}:${data[tag]}" 2>/dev/null || true)
+          if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]
+          then
+            printf '* Pushing component: %s\n' "${data[name]}"
+            skopeo copy \
+              --all \
+              --preserve-digests \
+              --dest-precompute-digests \
+              --retry-times="$(params.retries)" \
+              "docker://${data[containerImage]}" \
+              "docker://${data[repository]}:${data[tag]}" ;
+          else
+            printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
+              "${data[name]}" "$source_digest"
+          fi
+        done < <(jq -rc '.components[]' <<<'$(params.mappedSnapshot)')
+        printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/catalog/task/push-snapshot/0.4/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.4/push-snapshot.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: push-snapshot
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release

--- a/catalog/task/push-snapshot/0.4/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.4/push-snapshot.yaml
@@ -16,7 +16,7 @@ spec:
       description: JSON string representing the Snapshot
       type: string
     - name: tag
-      description: tag name to create on external registry
+      description: Default tag to use if mapping entry does not contain a tag
       type: string
       default: "latest"
     - name: retries

--- a/catalog/task/push-snapshot/0.4/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.4/push-snapshot.yaml
@@ -39,6 +39,7 @@ spec:
           while IFS== read -r key value; do
             data["$key"]="$value"
           done < <(jq -r '. | to_entries | .[] | .key + "=" + .value' <<<"$line")
+          # take tag if present in mapping file, otherwise take ReleaseStrategy default
           data[tag]="${data[tag]:=$(params.tag)}"
           typeset -p data
 

--- a/catalog/task/push-snapshot/0.4/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.4/samples/sample_push-snapshot_TaskRun.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: push-snapshot-run-empty-params
+spec:
+  params:
+    - name: mappedSnapshot
+      value: ""
+    - name: tag
+      value: "test"
+  taskRef:
+    name: push-snapshot
+    bundle: quay.io/hacbs-release/task-push-snapshot:0.4

--- a/catalog/task/push-snapshot/0.4/tests/run.yaml
+++ b/catalog/task/push-snapshot/0.4/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: push-snapshot-run-empty-params
+spec:
+  params:
+    - name: mappedSnapshot
+      value: ""
+    - name: tag
+      value: "test"
+  taskRef:
+    name: push-snapshot
+    bundle: quay.io/hacbs-release/task-push-snapshot:0.4


### PR DESCRIPTION
support the ability to use the Release Strategy existing tag parameter in the push-snapshot task instead of hard-coded latest

```
    - name: push-snapshot
      taskRef:
        name: push-snapshot
        bundle: quay.io/hacbs-release/task-push-snapshot:main
      params:
        - name: mappedSnapshot
          value: $(tasks.apply-mapping.results.snapshot)
        - name: tag
          value: $(params.tag) 
```

```
    - name: tag
      description: tag name to create on external registry
      type: string
      default: "latest"
```

` data[tag]="${data[tag]:=$(params.tag)}"`