### PR TITLE
fix(STONEBUGS-24): inspect without tags in push-snapshot

### DIFF
--- a/catalog/task/push-snapshot/0.5/README.md
+++ b/catalog/task/push-snapshot/0.5/README.md
@@ -18,6 +18,7 @@ Tekton task to push snapshot images to an image registry using `skopeo copy`.
   sha for each image in the snapshot
 * Parameter `addTimestampTag` was added. This parameter specifies whether or not to additionally push a tag with the
   current timestamp for each image in the snapshot
+* `skopeo inspect` has the `--no-tags` flag added to prevent timeouts on large repos
 
 ## Changes since 0.3
 

--- a/catalog/task/push-snapshot/0.5/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.5/push-snapshot.yaml
@@ -64,11 +64,13 @@ spec:
           typeset -p data
 
           source_digest=$(skopeo inspect \
+            --no-tags \
             --format '{{.Digest}}' \
             "docker://${data[containerImage]}" 2>/dev/null)
           # note: Inspection might fail on empty repos, hence `|| true`
           destination_digest=$(
             skopeo inspect \
+            --no-tags \
             --format '{{.Digest}}' \
             "docker://${data[repository]}:${data[tag]}" 2>/dev/null || true)
           if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]


### PR DESCRIPTION
The push-snapshot task is hanging on repos with a lot of tags. This commit adds the --no-tags flag to the skopeo inspects that are run as part of the push-snapshot task to prevent timeout issues.