### PR TITLE
feat(HACBS-2011): task push-snapshot can push a tag with git sha

### DIFF
--- a/catalog/pipeline/push-to-external-registry/0.5/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.5/README.md
@@ -1,0 +1,35 @@
+# Push to External Registry Pipeline
+
+Tekton pipeline to push images to an external registry.
+
+## Parameters
+
+| Name | Description | Optional | Default value |
+|------|-------------|----------|---------------|
+| snapshot | The Snapshot in JSON format | No | - |
+| enterpriseContractPolicy | JSON representation of the policy to be applied when validating the enterprise contract | No | - |
+| extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
+| extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
+| extraConfigPath | Path to the extra config file within the repository | No | - |
+| tag | The default tag to use when mapping file does not contain a tag | No | - |
+| addShaTag | When pushing the snapshot components, also push a tag with the image sha | Yes | true |
+| addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
+| pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
+| pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
+| postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.3
+
+* Upgrade push-snapshot task to version 0.5
+  * addShaTag parameter is now supported and passed as a pipeline parameter to the task
+  * addTimestampTag parameter is now supported and passed as a pipeline parameter to the task
+
+## Changes since 0.2
+
+* push-snapshot now supports tag parameter
+
+## Changes since 0.1
+
+* Upgrade create-pyxis-image task to version 0.2
+  * correct incorrect snapshot param
+

--- a/catalog/pipeline/push-to-external-registry/0.5/README.md
+++ b/catalog/pipeline/push-to-external-registry/0.5/README.md
@@ -12,11 +12,17 @@ Tekton pipeline to push images to an external registry.
 | extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
 | extraConfigPath | Path to the extra config file within the repository | No | - |
 | tag | The default tag to use when mapping file does not contain a tag | No | - |
-| addShaTag | When pushing the snapshot components, also push a tag with the image sha | Yes | true |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
+| addSourceShaTag | When pushing the snapshot components, also push a tag with the image source sha | Yes | true |
 | addTimestampTag | When pushing the snapshot components, also push a tag with the current timestamp | Yes | false |
 | pyxisServerType | The Pyxis server type to use. Options are 'production' and 'stage' | No | - |
 | pyxisSecret | The kubernetes secret to use to authenticate to Pyxis | No | - |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
+
+## Changes since 0.4
+* Upgrade push-snapshot task to version 0.6
+  * addShaTag parameter is now named addSourceShaTag
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task
 
 ## Changes since 0.3
 

--- a/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: push-to-external-registry
+  labels:
+    app.kubernetes.io/version: "0.5"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton pipeline to release HACBS Snapshot to Quay
+  params:
+    - name: snapshot
+      type: string
+      description: The Snapshot in JSON format
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: extraConfigGitUrl
+      type: string
+      description: URL to the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigGitRevision
+      type: string
+      description: Revision to fetch from the remote Git repository containing the extra config
+      default: ""
+    - name: extraConfigPath
+      type: string
+      description: Path to the extra config file within the repository
+      default: ""
+    - name: tag
+      type: string
+      description: The default tag to use when mapping file does not contain a tag
+    - name: addShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image sha
+      default: "true"
+    - name: addTimestampTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the current timestamp
+      default: "false"
+    - name: pyxisServerType
+      type: string
+      description: The Pyxis server type to use. Options are 'production' and 'stage'
+    - name: pyxisSecret
+      type: string
+      description: The kubernetes secret to use to authenticate to Pyxis
+    - name: postCleanUp
+      type: string
+      description: Cleans up workspace after finishing executing the pipeline
+      default: "true"
+  workspaces:
+    - name: release-workspace
+  tasks:
+    - name: clone-config-file
+      taskRef:
+        name: git-clone
+        bundle: quay.io/redhat-appstudio/appstudio-tasks:583d33c8ddf0de2ea8e1a73d94a1ca4a6e6ed380-1
+      when:
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: url
+          value: $(params.extraConfigGitUrl)
+        - name: revision
+          value: $(params.extraConfigGitRevision)
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: output
+          workspace: release-workspace
+    - name: apply-mapping
+      taskRef:
+        name: apply-mapping
+        bundle: quay.io/hacbs-release/task-apply-mapping:0.3
+      params:
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: extraConfigPath
+          value: "$(context.pipelineRun.uid)/$(params.extraConfigPath)"
+      when:
+        - input: $(tasks.clone-config-file.results.commit)
+          operator: notin
+          values: [""]
+      workspaces:
+        - name: config
+          workspace: release-workspace
+    - name: verify-enterprise-contract
+      taskRef:
+        name: verify-enterprise-contract
+        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot
+      params:
+        - name: IMAGES
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "1"
+    - name: push-snapshot
+      taskRef:
+        name: push-snapshot
+        bundle: quay.io/hacbs-release/task-push-snapshot:0.5
+      params:
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+        - name: tag
+          value: $(params.tag)
+        - name: addShaTag
+          value: $(params.addShaTag)
+        - name: addTimestampTag
+          value: $(params.addTimestampTag)
+      runAfter:
+        - verify-enterprise-contract
+    - name: create-pyxis-image
+      taskRef:
+        name: create-pyxis-image
+        bundle: quay.io/hacbs-release/task-create-pyxis-image:0.3
+      params:
+        - name: server
+          value: $(params.pyxisServerType)
+        - name: pyxisSecret
+          value: $(params.pyxisSecret)
+        - name: tag
+          value: $(params.tag)
+        - name: mappedSnapshot
+          value: $(tasks.apply-mapping.results.snapshot)
+      runAfter:
+        - push-snapshot
+  finally:
+    - name: cleanup
+      taskRef:
+        name: cleanup-workspace
+        bundle: quay.io/hacbs-release/task-cleanup-workspace:0.2
+      when:
+        - input: $(params.postCleanUp)
+          operator: in
+          values: ["true"]
+        - input: $(params.extraConfigGitUrl)
+          operator: notin
+          values: [""]
+      params:
+        - name: subdirectory
+          value: "$(context.pipelineRun.uid)"
+      workspaces:
+        - name: input
+          workspace: release-workspace

--- a/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.5/push-to-external-registry.yaml
@@ -33,9 +33,13 @@ spec:
     - name: tag
       type: string
       description: The default tag to use when mapping file does not contain a tag
-    - name: addShaTag
+    - name: addGitShaTag
       type: string
-      description: When pushing the snapshot components, also push a tag with the image sha
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
+    - name: addSourceShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image source sha
       default: "true"
     - name: addTimestampTag
       type: string
@@ -104,14 +108,16 @@ spec:
     - name: push-snapshot
       taskRef:
         name: push-snapshot
-        bundle: quay.io/hacbs-release/task-push-snapshot:0.5
+        bundle: quay.io/hacbs-release/task-push-snapshot:0.6
       params:
         - name: mappedSnapshot
           value: $(tasks.apply-mapping.results.snapshot)
         - name: tag
           value: $(params.tag)
-        - name: addShaTag
-          value: $(params.addShaTag)
+        - name: addGitShaTag
+          value: $(params.addGitShaTag)
+        - name: addSourceShaTag
+          value: $(params.addSourceShaTag)
         - name: addTimestampTag
           value: $(params.addTimestampTag)
       runAfter:

--- a/catalog/pipeline/push-to-external-registry/0.5/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.5/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: push-to-external-registry
+    bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:0.5

--- a/catalog/pipeline/push-to-external-registry/0.5/tests/run.yaml
+++ b/catalog/pipeline/push-to-external-registry/0.5/tests/run.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: push-to-external-registry-run-empty-params
+spec:
+  params:
+    - name: snapshot
+      value: ""
+    - name: enterpriseContractPolicy
+      value: ""
+    - name: extraConfigGitUrl
+      value: ""
+    - name: extraConfigGitRevision
+      value: ""
+    - name: extraConfigPath
+      value: ""
+    - name: pyxisServerType
+      value: ""
+    - name: pyxisSecret
+      value: ""
+    - name: tag
+      value: ""
+    - name: postCleanUp
+      value: ""
+  pipelineRef:
+    name: push-to-external-registry
+    bundle: quay.io/hacbs-release/pipeline-push-to-external-registry:0.5

--- a/catalog/task/push-snapshot/0.6/README.md
+++ b/catalog/task/push-snapshot/0.6/README.md
@@ -1,0 +1,38 @@
+# push-snapshot
+
+Tekton task to push snapshot images to an image registry using `skopeo copy`.
+
+## Parameters
+
+| Name            | Description                                                                                     | Optional | Default value |
+|-----------------|-------------------------------------------------------------------------------------------------|----------|---------------|
+| mappedSnapshot  | JSON string representing the Snapshot                                                           | No       | -             |
+| tag             | Default tag to use if mapping entry does not contain a tag                                      | Yes      | latest        |
+| retries         | Retry copy N times                                                                              | Yes      | 0             |
+| addShaTag       | Also push a tag with the sha for each image in the Snapshot                                     | Yes      | true          |
+| addTimestampTag | Also push a tag with the current timestamp for each image in the Snapshot                       | Yes      | false         |
+
+## Changes since 0.4
+
+* Parameter `addShaTag` was added. This parameter specifies whether or not to additionally push a tag with the
+  sha for each image in the snapshot
+* Parameter `addTimestampTag` was added. This parameter specifies whether or not to additionally push a tag with the
+  current timestamp for each image in the snapshot
+* `skopeo inspect` has the `--no-tags` flag added to prevent timeouts on large repos
+
+## Changes since 0.3
+
+* Default tag to use will default to `tag` parameter
+
+## Changes since 0.2
+
+* Base image was changed from `release-utils` to `release-base-image`
+
+## Changes since 0.1 (milestone-8)
+
+* Task `samples/sample_push-application-snapshot_TaskRun.yaml` was renamed to `samples/sample_push-snapshot_TaskRun.yaml`
+* Task `push-application-snapshot` was renamed to `push-snapshot`
+* Task `push-snapshot` was changed
+  * Task parameter `mappedApplicationSnapshot` value was changed
+    * old: $(params.mappedApplicationSnapshot)
+    * new: $(params.mappedSnapshot)

--- a/catalog/task/push-snapshot/0.6/README.md
+++ b/catalog/task/push-snapshot/0.6/README.md
@@ -9,8 +9,15 @@ Tekton task to push snapshot images to an image registry using `skopeo copy`.
 | mappedSnapshot  | JSON string representing the Snapshot                                                           | No       | -             |
 | tag             | Default tag to use if mapping entry does not contain a tag                                      | Yes      | latest        |
 | retries         | Retry copy N times                                                                              | Yes      | 0             |
-| addShaTag       | Also push a tag with the sha for each image in the Snapshot                                     | Yes      | true          |
+| addGitShaTag    | Also push a tag with the git sha for each image in the Snapshot                                 | Yes      | true          |
+| addSourceShaTag | Also push a tag with the source sha for each image in the Snapshot                              | Yes      | true          |
 | addTimestampTag | Also push a tag with the current timestamp for each image in the Snapshot                       | Yes      | false         |
+
+## Changes since 0.5
+* JSON data interpretation logic was switched from creating a bash array to using `jq`
+* Parameter `addShaTag` was renamed to `addSourceShaTag`
+* Parameter `addGitShaTag` was added. This parameter specifies whether or not to additionally push a tag with the
+  git sha for each image in the snapshot
 
 ## Changes since 0.4
 

--- a/catalog/task/push-snapshot/0.6/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.6/push-snapshot.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: push-snapshot
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Tekton task to push snapshot images to an image registry using `skopeo copy`
+  params:
+    - name: mappedSnapshot
+      description: JSON string representing the Snapshot
+      type: string
+    - name: tag
+      description: Default tag to use if mapping entry does not contain a tag
+      type: string
+      default: "latest"
+    - name: retries
+      description: Retry copy N times.
+      type: string
+      default: "0"
+    - name: addShaTag
+      description: Also push a tag with the sha for each image in the Snapshot
+      type: string
+      default: "true"
+    - name: addTimestampTag
+      description: Also push a tag with the current timestamp for each image in the Snapshot
+      type: string
+      default: "false"
+  steps:
+    - name: push-snapshot
+      image:
+        quay.io/hacbs-release/release-base-image@sha256:9e7fd1a3ccf0d2c8077f565c78e50862a7cc4792d548b5c01c8b09077e6d23a7
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+
+        push_image () { # Expected arguments are [name, containerImage, repository, tag] from data array
+          printf '* Pushing component: %s to %s:%s\n' "$1" "$3" "$4"
+          skopeo copy \
+            --all \
+            --preserve-digests \
+            --dest-precompute-digests \
+            --retry-times="$(params.retries)" \
+            "docker://$2" \
+            "docker://$3:$4"
+        }
+
+        application=$(jq -r '.application' <<<'$(params.mappedSnapshot)')
+        printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
+        while read line;
+        do
+          # Create array with component values
+          typeset -A data
+          while IFS== read -r key value; do
+            data["$key"]="$value"
+          done < <(jq -r '. | to_entries | .[] | .key + "=" + .value' <<<"$line")
+          # take tag if present in mapping file, otherwise take ReleaseStrategy default
+          data[tag]="${data[tag]:=$(params.tag)}"
+          typeset -p data
+
+          source_digest=$(skopeo inspect \
+            --no-tags \
+            --format '{{.Digest}}' \
+            "docker://${data[containerImage]}" 2>/dev/null)
+          # note: Inspection might fail on empty repos, hence `|| true`
+          destination_digest=$(
+            skopeo inspect \
+            --no-tags \
+            --format '{{.Digest}}' \
+            "docker://${data[repository]}:${data[tag]}" 2>/dev/null || true)
+          if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]
+          then
+            push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "${data[tag]}"
+            if [ $(params.addTimestampTag) = true ] ; then
+              timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
+              push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "$timestamp"
+            fi
+            if [ $(params.addShaTag) = true ] ; then
+              if [[ "${data[containerImage]}" == *"@sha256"* && \
+                $(echo "${data[containerImage]}" | tr -cd ':' | wc -c) -eq 1 ]]
+              then
+                sha=$(echo "${data[containerImage]}" | cut -d ':' -f 2)
+                push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "$sha"
+              else
+                printf 'Asked to create sha based tag, but no sha found in %s\n' "${data[containerImage]}"
+                exit 1
+              fi
+            fi
+          else
+            printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
+              "${data[name]}" "$source_digest"
+          fi
+        done < <(jq -rc '.components[]' <<<'$(params.mappedSnapshot)')
+        printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/catalog/task/push-snapshot/0.6/push-snapshot.yaml
+++ b/catalog/task/push-snapshot/0.6/push-snapshot.yaml
@@ -23,8 +23,12 @@ spec:
       description: Retry copy N times.
       type: string
       default: "0"
-    - name: addShaTag
-      description: Also push a tag with the sha for each image in the Snapshot
+    - name: addGitShaTag
+      description: Also push a tag with the git sha for each image in the Snapshot
+      type: string
+      default: "true"
+    - name: addSourceShaTag
+      description: Also push a tag with the source sha for each image in the Snapshot
       type: string
       default: "true"
     - name: addTimestampTag
@@ -39,7 +43,7 @@ spec:
         #!/usr/bin/env bash
         set -eux
 
-        push_image () { # Expected arguments are [name, containerImage, repository, tag] from data array
+        push_image () { # Expected arguments are [name, containerImage, repository, tag]
           printf '* Pushing component: %s to %s:%s\n' "$1" "$3" "$4"
           skopeo copy \
             --all \
@@ -52,48 +56,55 @@ spec:
 
         application=$(jq -r '.application' <<<'$(params.mappedSnapshot)')
         printf 'Beginning "%s" for "%s"\n\n' "$(context.task.name)" "$application"
-        while read line;
+        for component in $(jq -rc '.components[]' <<< '$(params.mappedSnapshot)')
         do
-          # Create array with component values
-          typeset -A data
-          while IFS== read -r key value; do
-            data["$key"]="$value"
-          done < <(jq -r '. | to_entries | .[] | .key + "=" + .value' <<<"$line")
-          # take tag if present in mapping file, otherwise take ReleaseStrategy default
-          data[tag]="${data[tag]:=$(params.tag)}"
-          typeset -p data
+          containerImage=$(jq -r '.containerImage' <<< $component)
+          repository=$(jq -r '.repository' <<< $component)
+          name=$(jq -r '.name' <<< $component)
+          git_sha=$(jq -r '.source.git.revision' <<< $component) # this sets the value to "null" if it doesn't exist
+          # take tag if present in mapping file, otherwise take ReleaseStrategy default provided as a task param
+          tag=$(params.tag)
+          if [ $(jq 'has("tag")' <<< $component) == "true" ] ; then
+              tag=$(jq -r '.tag' <<< $component)
+          fi
 
           source_digest=$(skopeo inspect \
             --no-tags \
             --format '{{.Digest}}' \
-            "docker://${data[containerImage]}" 2>/dev/null)
+            "docker://${containerImage}" 2>/dev/null)
           # note: Inspection might fail on empty repos, hence `|| true`
           destination_digest=$(
             skopeo inspect \
             --no-tags \
             --format '{{.Digest}}' \
-            "docker://${data[repository]}:${data[tag]}" 2>/dev/null || true)
-          if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]
-          then
-            push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "${data[tag]}"
+            "docker://${repository}:${tag}" 2>/dev/null || true)
+          if [[ "$destination_digest" != "$source_digest" || -z "$destination_digest" ]]; then
+            push_image "${name}" "${containerImage}" "${repository}" "${tag}"
             if [ $(params.addTimestampTag) = true ] ; then
               timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ" | sed 's/:/-/g')
-              push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "$timestamp"
+              push_image "${name}" "${containerImage}" "${repository}" "$timestamp"
             fi
-            if [ $(params.addShaTag) = true ] ; then
-              if [[ "${data[containerImage]}" == *"@sha256"* && \
-                $(echo "${data[containerImage]}" | tr -cd ':' | wc -c) -eq 1 ]]
-              then
-                sha=$(echo "${data[containerImage]}" | cut -d ':' -f 2)
-                push_image "${data[name]}" "${data[containerImage]}" "${data[repository]}" "$sha"
+            if [ $(params.addGitShaTag) = true ] ; then
+              if [ "${git_sha}" != "null" ] ; then
+                push_image "${name}" "${containerImage}" "${repository}" "${git_sha}"
               else
-                printf 'Asked to create sha based tag, but no sha found in %s\n' "${data[containerImage]}"
+                printf 'Asked to create git sha based tag, but no git sha found in %s\n' "${component}"
+                exit 1
+              fi
+            fi
+            if [ $(params.addSourceShaTag) = true ] ; then
+              if [[ "${containerImage}" == *"@sha256"* && $(echo "${containerImage}" | tr -cd ':' | wc -c) -eq 1 ]]
+              then
+                sha=$(echo "${containerImage}" | cut -d ':' -f 2)
+                push_image "${name}" "${containerImage}" "${repository}" "${sha}"
+              else
+                printf 'Asked to create source sha based tag, but no sha found in %s\n' "${containerImage}"
                 exit 1
               fi
             fi
           else
             printf '* Component push skipped (source digest exists at destination): %s (%s)\n' \
-              "${data[name]}" "$source_digest"
+              "${name}" "$source_digest"
           fi
-        done < <(jq -rc '.components[]' <<<'$(params.mappedSnapshot)')
+        done
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$application"

--- a/catalog/task/push-snapshot/0.6/samples/sample_push-snapshot_TaskRun.yaml
+++ b/catalog/task/push-snapshot/0.6/samples/sample_push-snapshot_TaskRun.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: push-snapshot-run-empty-params
+spec:
+  params:
+    - name: mappedSnapshot
+      value: ""
+    - name: tag
+      value: "test"
+  taskRef:
+    name: push-snapshot
+    bundle: quay.io/hacbs-release/task-push-snapshot:0.6

--- a/catalog/task/push-snapshot/0.6/tests/run.yaml
+++ b/catalog/task/push-snapshot/0.6/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: push-snapshot-run-empty-params
+spec:
+  params:
+    - name: mappedSnapshot
+      value: ""
+    - name: tag
+      value: "test"
+  taskRef:
+    name: push-snapshot
+    bundle: quay.io/hacbs-release/task-push-snapshot:0.6


### PR DESCRIPTION
This PR adds the `addGitShaTag` parameter to the `push-snapshot` task. When true, a sha will be looked for in the snapshot for each component and a tag will be pushed with said sha when pushing to the external registry

The work to inject the git sha in the snapshot is not yet complete, so marking this as do not merge for now