### PR TITLE
fix(HACBS-2061): pipeline-release should use addGitShaTag false

### DIFF
--- a/catalog/pipeline/release/0.9/README.md
+++ b/catalog/pipeline/release/0.9/README.md
@@ -11,11 +11,15 @@ Tekton pipeline to release Stonesoup Snapshot to Quay.
 | extraConfigGitUrl |URL to the remote Git repository containing the extra config | No | - |
 | extraConfigGitRevision | Revision to fetch from the remote Git repository containing the extra config | No | - |
 | extraConfigPath | Path to the extra config file within the repository | No | - |
+| addGitShaTag | When pushing the snapshot components, also push a tag with the image git sha | Yes | false |
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 
 ## Changes since 0.8
 
-Update tag of ec-task-bundle task
+* Update tag of ec-task-bundle task
+* Upgrade push-snapshot task for v0.6 parameter
+  * addGitShaTag parameter is now supported and passed as a pipeline parameter to the task with value false
+
 
 ## Changes since 0.7
 

--- a/catalog/pipeline/release/0.9/release.yaml
+++ b/catalog/pipeline/release/0.9/release.yaml
@@ -30,6 +30,10 @@ spec:
       type: string
       description: Path to the extra config file within the repository
       default: ""
+    - name: addGitShaTag
+      type: string
+      description: When pushing the snapshot components, also push a tag with the image git sha
+      default: "false"
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline


### PR DESCRIPTION
The pipeline named release uses push-snapshot:main. The push-snapshot task was modified to add git sha tags, with task default to true. However, this functionality is not ready yet, so pipelines calling this task should pass this parameter as false for now.